### PR TITLE
Fix reference to SparseMatrixCSC

### DIFF
--- a/src/prob/sacdcpf.jl
+++ b/src/prob/sacdcpf.jl
@@ -544,7 +544,7 @@ function _compute_dc_pf(dcpf_data::DCPowerFlowData; finite_differencing=false, f
 
 
     # dc power flow, sparse jacobian computation
-    function jsp!(J::_PM.SparseMatrixCSC{Float64,Int}, x::Vector{Float64})
+    function jsp!(J::_PM.SparseArrays.SparseMatrixCSC{Float64,Int}, x::Vector{Float64})
         for i in eachindex(amdc.idx_to_bus)
 
             for j in neighbors[i]


### PR DESCRIPTION
Need to explicitly reference the SparseArrays module. I believe this appears due to the very recent release of PowerModels [v0.21.4](https://github.com/lanl-ansi/PowerModels.jl/releases/tag/v0.21.4) and the change in https://github.com/lanl-ansi/PowerModels.jl/pull/961