### PR TITLE
Avoid logger piracy

### DIFF
--- a/src/PowerModelsACDC.jl
+++ b/src/PowerModelsACDC.jl
@@ -20,8 +20,8 @@ export optimizer_with_attributes
 # Create our module level logger (this will get precompiled)
 const _LOGGER = Memento.getlogger(@__MODULE__)
 
-# Register the module level logger at runtime so that folks can access the logger via `getlogger(PowerModels)`
-# NOTE: If this line is not included then the precompiled `_PM._LOGGER` won't be registered at runtime.
+# Register the module level logger at runtime so that folks can access the logger via `getlogger(PowerModelsACDC)`
+# NOTE: If this line is not included then the precompiled `PowerModelsACDC._LOGGER` won't be registered at runtime.
 __init__() = Memento.register(_LOGGER)
 
 # paths

--- a/src/core/base.jl
+++ b/src/core/base.jl
@@ -35,11 +35,11 @@ function add_ref_dcgrid!(ref::Dict{Symbol,<:Any}, data::Dict{String,<:Any})
 
             # Bus converters for existing ac buses
             bus_convs_ac = Dict([(i, []) for (i,bus) in nw_ref[:bus]])
-            nw_ref[:bus_convs_ac] = assign_bus_converters!(nw_ref[:convdc], bus_convs_ac, "busac_i")    
+            nw_ref[:bus_convs_ac] = assign_bus_converters!(nw_ref[:convdc], bus_convs_ac, "busac_i")
 
             # Bus converters for existing ac buses
             bus_convs_dc = Dict([(bus["busdc_i"], []) for (i,bus) in nw_ref[:busdc]])
-            nw_ref[:bus_convs_dc]= assign_bus_converters!(nw_ref[:convdc], bus_convs_dc, "busdc_i") 
+            nw_ref[:bus_convs_dc]= assign_bus_converters!(nw_ref[:convdc], bus_convs_dc, "busdc_i")
 
 
             # Add DC reference buses
@@ -56,22 +56,22 @@ function add_ref_dcgrid!(ref::Dict{Symbol,<:Any}, data::Dict{String,<:Any})
                         ref_buses_dc["$k"] = v
                     end
                 end
-                Memento.warn(_PM._LOGGER, "no reference DC bus found, setting reference bus based on AC bus type")
+                Memento.warn(_LOGGER, "no reference DC bus found, setting reference bus based on AC bus type")
             end
 
             for (k,conv) in nw_ref[:convdc]
                 conv_id = conv["index"]
                 if conv["type_ac"] == 2 && conv["type_dc"] == 1
-                    Memento.warn(_PM._LOGGER, "For converter $conv_id is chosen P is fixed on AC and DC side. This can lead to infeasibility in the PF problem.")
+                    Memento.warn(_LOGGER, "For converter $conv_id is chosen P is fixed on AC and DC side. This can lead to infeasibility in the PF problem.")
                 elseif conv["type_ac"] == 1 && conv["type_dc"] == 1
-                    Memento.warn(_PM._LOGGER, "For converter $conv_id is chosen P is fixed on AC and DC side. This can lead to infeasibility in the PF problem.")
+                    Memento.warn(_LOGGER, "For converter $conv_id is chosen P is fixed on AC and DC side. This can lead to infeasibility in the PF problem.")
                 end
                 convbus_ac = conv["busac_i"]
                 if conv["Vmmax"] < nw_ref[:bus][convbus_ac]["vmin"]
-                    Memento.warn(_PM._LOGGER, "The maximum AC side voltage of converter $conv_id is smaller than the minimum AC bus voltage")
+                    Memento.warn(_LOGGER, "The maximum AC side voltage of converter $conv_id is smaller than the minimum AC bus voltage")
                 end
                 if conv["Vmmin"] > nw_ref[:bus][convbus_ac]["vmax"]
-                    Memento.warn(_PM._LOGGER, "The miximum AC side voltage of converter $conv_id is larger than the maximum AC bus voltage")
+                    Memento.warn(_LOGGER, "The miximum AC side voltage of converter $conv_id is larger than the maximum AC bus voltage")
                 end
             end
 
@@ -80,7 +80,7 @@ function add_ref_dcgrid!(ref::Dict{Symbol,<:Any}, data::Dict{String,<:Any})
                 for (rb) in keys(ref_buses_dc)
                     ref_buses_warn = ref_buses_warn*rb*", "
                 end
-                Memento.warn(_PM._LOGGER, "multiple reference buses found, i.e. "*ref_buses_warn*"this can cause infeasibility if they are in the same connected component")
+                Memento.warn(_LOGGER, "multiple reference buses found, i.e. "*ref_buses_warn*"this can cause infeasibility if they are in the same connected component")
             end
             nw_ref[:ref_buses_dc] = ref_buses_dc
             nw_ref[:buspairsdc] = buspair_parameters_dc(nw_ref[:arcs_dcgrid_from], nw_ref[:branchdc], nw_ref[:busdc])
@@ -92,7 +92,7 @@ function add_ref_dcgrid!(ref::Dict{Symbol,<:Any}, data::Dict{String,<:Any})
             nw_ref[:buspairsdc] = Dict{String, Any}()
             # Bus converters for existing ac buses
             bus_convs_ac = Dict([(i, []) for (i,bus) in nw_ref[:bus]])
-            nw_ref[:bus_convs_ac] = assign_bus_converters!(nw_ref[:convdc], bus_convs_ac, "busac_i")    
+            nw_ref[:bus_convs_ac] = assign_bus_converters!(nw_ref[:convdc], bus_convs_ac, "busac_i")
         end
     end
 end
@@ -231,7 +231,7 @@ function add_candidate_dcgrid!(ref::Dict{Symbol,<:Any}, data::Dict{String,<:Any}
         if haskey(nw_ref, :convdc_ne)
             nw_ref[:arcs_conv_acdc_ne] = [(i,conv["busac_i"],conv["busdc_i"]) for (i,conv) in nw_ref[:convdc_ne]]
             nw_ref[:arcs_conv_acdc_acbus_ne] = [(i,conv["busac_i"]) for (i,conv) in nw_ref[:convdc_ne]]
-            
+
             # Bus converters for existing ac buses
             bus_convs_ac_ne = Dict([(i, []) for (i,bus) in nw_ref[:bus]])
             nw_ref[:bus_convs_ac_ne] = assign_bus_converters!(nw_ref[:convdc_ne], bus_convs_ac_ne, "busac_i")
@@ -408,7 +408,7 @@ function ref_add_gendc!(ref::Dict{Symbol,<:Any}, data::Dict{String,<:Any})
         # Bus converters for existing ac buses
 
         bus_gens_dc = Dict((i, Int[]) for (i,bus) in nw_ref[:busdc])
-        nw_ref[:bus_gens_dc]= assign_bus_generators!(nw_ref[:gendc], bus_gens_dc, "gen_bus") 
+        nw_ref[:bus_gens_dc]= assign_bus_generators!(nw_ref[:gendc], bus_gens_dc, "gen_bus")
     end
 end
 

--- a/src/core/constraint_template.jl
+++ b/src/core/constraint_template.jl
@@ -161,9 +161,9 @@ function constraint_dc_droop_control(pm::_PM.AbstractPowerModel, i::Int; nw::Int
         elseif type == 4
             constraint_dc_droop_control(pm, nw, i, conv["busdc_i"], conv["Vdcset"], conv["Pacset"], conv["droop"]; dc_power = false)
         else
-            Memento.warn(_PM._LOGGER, "Invalid setting for DC converter control type, droop constraint will be ignored")
+            Memento.warn(_LOGGER, "Invalid setting for DC converter control type, droop constraint will be ignored")
         end
-    end 
+    end
 end
 
 function constraint_ac_voltage_droop_control(pm::_PM.AbstractPowerModel, i::Int; nw::Int=_PM.nw_id_default)

--- a/src/core/data.jl
+++ b/src/core/data.jl
@@ -270,7 +270,7 @@ function rescale_dcgen_cost_model!(gendc, MVAbase)
     gendc["cost"] = [gendc["quadratic_cost"] * MVAbase^2 gendc["linear_cost"] * MVAbase gendc["idle_cost"]]
 end
 
-### Auxiliary functions 
+### Auxiliary functions
 
 function is_single_network(data)
     return !haskey(data, "multinetwork") || data["multinetwork"] == false
@@ -315,7 +315,7 @@ function to_pu_single_network!(data)
             Zbase = get_pu_bases(MVAbase, kVbase)["Z"]
             Ibase = get_pu_bases(MVAbase, kVbase)["I"]
 
-            set_conv_pu_power(conv, MVAbase) 
+            set_conv_pu_power(conv, MVAbase)
             set_conv_pu_volt(conv, kVbase*sqrt(3))
             set_conv_pu_ohm(conv, Zbase)
         end
@@ -678,14 +678,14 @@ function check_conv_parameters(conv)
     conv["Pacrated"] = max(abs(conv["Pacmax"]),abs(conv["Pacmin"]))
     conv["Qacrated"] = max(abs(conv["Qacmax"]),abs(conv["Qacmin"]))
     if conv["Imax"] < sqrt(conv["Pacrated"]^2 + conv["Qacrated"]^2)
-        Memento.warn(_PM._LOGGER, "Inconsistent current limit for converter $conv_id, it will be updated.")
+        Memento.warn(_LOGGER, "Inconsistent current limit for converter $conv_id, it will be updated.")
         conv["Imax"] = sqrt(conv["Pacrated"]^2 + conv["Qacrated"]^2)
     end
     if conv["LossCrec"] != conv["LossCinv"]
-        Memento.warn(_PM._LOGGER, "The losses of converter $conv_id are different in inverter and rectifier mode, inverter losses are used.")
+        Memento.warn(_LOGGER, "The losses of converter $conv_id are different in inverter and rectifier mode, inverter losses are used.")
     end
     if conv["islcc"] == 1
-        Memento.warn(_PM._LOGGER, "Converter $conv_id is an LCC, reactive power limits might be updated.")
+        Memento.warn(_LOGGER, "Converter $conv_id is an LCC, reactive power limits might be updated.")
         if abs(conv["Pacmax"]) >= abs(conv["Pacmin"])
             conv["phimin"] = 0
             conv["phimax"] = acos(conv["Pacmin"] / conv["Pacmax"])
@@ -918,12 +918,12 @@ function create_multinetwork_uc_model!(data, number_of_hours, g_series, l_series
         if contingencies["type"] == "N-1"
             number_of_contingencies = 1
             for element_type in contingencies["elements"]
-                number_of_contingencies = number_of_contingencies + length(data[element_type]) 
+                number_of_contingencies = number_of_contingencies + length(data[element_type])
             end
         elseif contingencies["type"] == "largest"
             number_of_contingencies = 1 + length(contingencies["elements"]) * length(data["zones"])
         end
-        
+
         replicates = number_of_hours * number_of_contingencies
         # This for loop determines which "network" belongs to an hour, and which to a contingency, for book-keeping of the network ids
         # Format: [h1, c1 ... cn, h2, c1 ... cn, .... , hn, c1 ... cn]
@@ -944,13 +944,13 @@ function create_multinetwork_uc_model!(data, number_of_hours, g_series, l_series
         for i in 1:replicates
             push!(hour_ids, i)
         end
-    end        
+    end
 
     ########### Using _IM.replicate networks
 
     mn_data = _IM.replicate(data, replicates, Set{String}(["source_type", "name", "source_version", "per_unit"]))
 
-    # Add hour_ids and contingency_ids to the data dictionary 
+    # Add hour_ids and contingency_ids to the data dictionary
     mn_data["hour_ids"] = hour_ids
     mn_data["cont_ids"] = cont_ids
     mn_data["number_of_hours"] = number_of_hours
@@ -1035,11 +1035,11 @@ function prepare_redispatch_opf_data(reference_solution, grid_data; contingency 
                 gen["dispatch_status"] = 0
             else
                 gen["dispatch_status"] = 1
-            end 
+            end
         else
             gen["dispatch_status"] = 0
         end
-        
+
         gen["rdcost_up"] = gen["cost"][1] * rd_cost_factor
         gen["rdcost_down"] = gen["cost"][1] * rd_cost_factor * 0
     end
@@ -1138,7 +1138,7 @@ function create_scopf_data(data_in, number_of_hours, g_series, l_series; number_
 
     process_additional_data!(data)
 
-    # Add hour_ids and contingency_ids to the data dictionary 
+    # Add hour_ids and contingency_ids to the data dictionary
     data["hour_ids"] = hour_ids
     data["cont_ids"] = cont_ids
     data["number_of_hours"] = number_of_hours

--- a/src/io/multinetwork.jl
+++ b/src/io/multinetwork.jl
@@ -42,15 +42,15 @@ function multinetwork_data(sn_data::Dict{String,Any}, extradata::Dict{String,Any
                                 if haskey(mn_data["nw"]["$n"][key][l], m)
                                     mn_data["nw"]["$n"][key][l][m] = property[n]
                                 else
-                                    Memento.warn(_PM._LOGGER, ["Property ", m ," for , ", key, " " , l, " not found, will be ingnored"])
+                                    Memento.warn(_LOGGER, ["Property ", m ," for , ", key, " " , l, " not found, will be ignored"])
                                 end
                             end
                         else
-                            Memento.warn(_PM._LOGGER, [key, " " , l,  " not found, will be ingnored"])
+                            Memento.warn(_LOGGER, [key, " " , l,  " not found, will be ignored"])
                         end
                     end
                 else
-                    Memento.warn(_PM._LOGGER, ["Key ", key, " not found, will be ingnored"])
+                    Memento.warn(_LOGGER, ["Key ", key, " not found, will be ignored"])
                 end
             end
         end

--- a/src/prob/acdcopf_iv.jl
+++ b/src/prob/acdcopf_iv.jl
@@ -121,17 +121,17 @@ function build_acdcopf_iv(pm::_PM.AbstractIVRModel)
     for i in _PM.ids(pm, :flex_load)
         constraint_total_flexible_demand(pm, i)
     end
-    
-    for i in _PM.ids(pm, :fixed_load) 
+
+    for i in _PM.ids(pm, :fixed_load)
         constraint_total_fixed_demand(pm, i)
     end
 
     for i in _PM.ids(pm, :pst)
-        Memento.warn(_PM._LOGGER,"IVR formulation is not yet implemented for PSTs")
+        Memento.warn(_LOGGER,"IVR formulation is not yet implemented for PSTs")
     end
 
     for i in _PM.ids(pm, :sssc)
-        Memento.warn(_PM._LOGGER,"IVR formulation is not yet implemented for SSSCs")
+        Memento.warn(_LOGGER,"IVR formulation is not yet implemented for SSSCs")
     end
 
     for i in _PM.ids(pm, :busdc)
@@ -230,11 +230,11 @@ function mp_build_acdcopf_iv(pm::_PM.AbstractIVRModel)
         end
 
         for i in _PM.ids(pm, n, :pst)
-            Memento.warn(_PM._LOGGER,"IVR formulation is not yet implemented for PSTs (nw = $n)")
+            Memento.warn(_LOGGER,"IVR formulation is not yet implemented for PSTs (nw = $n)")
         end
 
         for i in _PM.ids(pm, n, :sssc)
-            Memento.warn(_PM._LOGGER,"IVR formulation is not yet implemented for SSSCs (nw = $n)")
+            Memento.warn(_LOGGER,"IVR formulation is not yet implemented for SSSCs (nw = $n)")
         end
 
         for i in _PM.ids(pm, n, :busdc)

--- a/src/prob/acdcpf.jl
+++ b/src/prob/acdcpf.jl
@@ -140,8 +140,8 @@ function build_acdcpf(pm::_PM.AbstractPowerModel)
     for i in _PM.ids(pm, :flex_load)
         constraint_total_flexible_demand(pm, i)
     end
-    
-    for i in _PM.ids(pm, :fixed_load) 
+
+    for i in _PM.ids(pm, :fixed_load)
         constraint_total_fixed_demand(pm, i)
     end
 
@@ -152,7 +152,7 @@ function build_acdcpf(pm::_PM.AbstractPowerModel)
         constraint_ohms_dc_branch(pm, i)
     end
 
-    if !isempty(_PM.ids(pm, :gendc)) 
+    if !isempty(_PM.ids(pm, :gendc))
         for i in _PM.ids(pm, :gendc)
             constraint_dcgenerator_voltage_and_power(pm, i)
         end
@@ -168,7 +168,7 @@ function build_acdcpf(pm::_PM.AbstractPowerModel)
             if typeof(pm) <: _PM.AbstractACPModel || typeof(pm) <: _PM.AbstractACRModel
                 constraint_dc_droop_control(pm, c)
             else
-                Memento.warn(_PM._LOGGER, join(["Droop only defined for ACP and ACR formulations, converter ", c, " will be treated as type 2"]))
+                Memento.warn(_LOGGER, join(["Droop only defined for ACP and ACR formulations, converter ", c, " will be treated as type 2"]))
                 constraint_dc_voltage_magnitude_setpoint(pm, c)
             end
         else


### PR DESCRIPTION
In some cases, PowerModelsACDC used PowerModels’ Memento logger (an unexported constant) instead of its own. This caused errors when Memento was removed in PowerModels 0.21.6.

Solves #115, as well as the [recent CI failures](https://github.com/Electa-Git/PowerModelsACDC.jl/actions/runs/25540929206).