### PR TITLE
Fix random CI failures in PST unit tests

### DIFF
--- a/test/pst.jl
+++ b/test/pst.jl
@@ -1,12 +1,12 @@
 @testset "Phase Shifting Transformer" begin
     data = parse_file(pkgdir(PowerModelsACDC, "test", "data", "case5_acdc_pst_3_grids.m"))
-    s = Dict("conv_losses_mp" => true, "objective_components" => ["gen", "demand"])
+    s = Dict("conv_losses_mp" => false, "objective_components" => ["gen", "demand"])
     @testset "DCPPowerModel" begin
         result = solve_acdcopf(data, PowerModels.DCPPowerModel, highs; setting=s)
         @test result["termination_status"] == OPTIMAL
-        @test result["objective"] ≈ 24022 rtol=1e-3
-        @test result["solution"]["gen"]["3"]["pg"] ≈ 0.9552 rtol=1e-3
-        @test result["solution"]["branch"]["2"]["pt"] ≈ -1.2017 rtol=1e-3
-        @test result["solution"]["convdc"]["4"]["ptf_to"] ≈ 0.9779 rtol=1e-3
+        @test result["objective"] ≈ 24039 rtol=1e-3
+        @test result["solution"]["gen"]["3"]["pg"] ≈ 0.9963 rtol=1e-3
+        @test result["solution"]["branch"]["2"]["pt"] ≈ -1.6066 rtol=1e-3
+        @test result["solution"]["convdc"]["4"]["ptf_to"] ≈ 0.9370 rtol=1e-3
     end
 end


### PR DESCRIPTION
This PR fixes random PST unit test failures in CI, such as [this one](https://github.com/Electa-Git/PowerModelsACDC.jl/actions/runs/31098511989/job/92606172458?pr=133).

In the test case, all converters use the same loss parameter values. With `conv_losses_mp` set to `true`, negative losses cancel out positive losses, creating symmetries in the model because different power flows are equally valid for the OPF.

Setting `conv_losses_mp` to `false` solves the issue.

